### PR TITLE
add navigate to frontend folder before npm ci in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Navigate to frontend folder
+        run: cd frontend
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/build.yml` file. The change adds a step to navigate to the `frontend` folder before installing dependencies.

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R19-R21): Added a step to navigate to the `frontend` folder before running `npm ci`.