### PR TITLE
add webhook

### DIFF
--- a/.github/workflows/docker-image_dev.yml
+++ b/.github/workflows/docker-image_dev.yml
@@ -58,3 +58,7 @@ jobs:
           push: true
           tags: ${{ steps.meta-web.outputs.tags }}
           labels: ${{ steps.meta-web.outputs.labels }}
+
+      - name: Trigger Portainer Webhook
+        run: |
+          curl -X POST "https://portainer.hagenfaber.dev/api/stacks/webhooks/212a5f72-2990-474b-bf39-01a361376605"


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/docker-image_dev.yml` file. The change adds a step to trigger a Portainer webhook after the Docker image is built.

* [`.github/workflows/docker-image_dev.yml`](diffhunk://#diff-b65206136142f2b636eb21b47a95abd7b138ae6cb2593648ff3fe7de95b79671R61-R64): Added a step to trigger a Portainer webhook to update the stack after pushing the Docker image.